### PR TITLE
Add minimal Stack build file

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-10.5


### PR DESCRIPTION
So I know most of you use Other Build Tools™ but a _stack.yaml_ mentioning a recent resolver where your library code was recently known to build is a nice gesture (and, if you had a test suite, saying what your test suite was recently known to pass on is the same; doesn't mean for a moment anyone has to use that or any other snapshot).

Your code is building on GHC 8.2 against resolver `lts-10.5`. File to that effect included.

AfC