### PR TITLE
Fixup doc formatting and swap order of handleLeftT parameters.

### DIFF
--- a/src/Control/Monad/Trans/Either/Exit.hs
+++ b/src/Control/Monad/Trans/Either/Exit.hs
@@ -17,7 +17,6 @@ import           System.IO (IO, stderr, hPutStrLn)
 
 import           Control.Monad.Trans.Either
 
-
 -- | orDieWithCode with an exit code of 1 in case of an error
 --
 orDie :: (e -> Text) -> EitherT e IO a -> IO a


### PR DESCRIPTION
Most  funtions have  alternatives that just differ in parameter order.  has the handler second, which  has the handler first. By that convention what we have there should be called  (Thanks Erikd)